### PR TITLE
Do not throw error for TypedArrays

### DIFF
--- a/array-flatten.js
+++ b/array-flatten.js
@@ -15,6 +15,8 @@ module.exports.fromDepth = flattenFromDepth
  * @return {Array}
  */
 function flatten (array) {
+  if (ArrayBuffer.isView(array)) return array;
+  
   if (!Array.isArray(array)) {
     throw new TypeError('Expected value to be an array')
   }

--- a/array-flatten.js
+++ b/array-flatten.js
@@ -18,7 +18,7 @@ function flatten (array) {
   if (ArrayBuffer.isView(array)) {
     return array
   }
-  
+
   if (!Array.isArray(array)) {
     throw new TypeError('Expected value to be an array')
   }

--- a/array-flatten.js
+++ b/array-flatten.js
@@ -15,7 +15,9 @@ module.exports.fromDepth = flattenFromDepth
  * @return {Array}
  */
 function flatten (array) {
-  if (ArrayBuffer.isView(array)) return array;
+  if (ArrayBuffer.isView(array)) {
+    return array
+  }
   
   if (!Array.isArray(array)) {
     throw new TypeError('Expected value to be an array')


### PR DESCRIPTION
Hi @blakeembrey!

This tiny enhancement recognizes typed arrays instead of throwing error.