### PR TITLE
Fix benchmarks

### DIFF
--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -10,7 +10,7 @@ var sample = [1, [2, [3, [4], 3], 2], 1]
 var flattenSuite = new Suite({
   cwd: __dirname,
   fixtures: 'fixtures/*.js',
-  add: 'code/flatten/*.js',
+  code: 'code/flatten/*.js',
   name: name,
   sample: [sample]
 })
@@ -22,7 +22,7 @@ flattenSuite.run(function (fixture) {
 var argsSuite = new Suite({
   cwd: __dirname,
   fixtures: 'fixtures/*.js',
-  add: 'code/arguments/*.js',
+  code: 'code/arguments/*.js',
   name: name,
   sample: sample
 })
@@ -32,7 +32,7 @@ argsSuite.run()
 var depthSuite = new Suite({
   cwd: __dirname,
   fixtures: 'fixtures/*.js',
-  add: 'code/depth/*.js',
+  code: 'code/depth/*.js',
   name: name,
   sample: [sample, 2]
 })


### PR DESCRIPTION
A dependency called benchmarked was updated in fc56f6b but that update contained a breaking change: jonschlinkert/benchmarked@fbf093e - see the [removal of the add property](https://github.com/jonschlinkert/benchmarked/commit/fbf093e#diff-168726dbe96b3ce427e7fedce31bb0bcL86) as well as the [addition of the code property](https://github.com/jonschlinkert/benchmarked/commit/fbf093e#diff-168726dbe96b3ce427e7fedce31bb0bcR63) that replaced the add property.

This commit makes the benchmarks run again, because it replaces `add` with `code` 😄 