### PR TITLE
Remove unused parameter

### DIFF
--- a/array-flatten.js
+++ b/array-flatten.js
@@ -29,7 +29,7 @@ function flatten (array) {
  * @return {Array}
  */
 function flattenFrom (array) {
-  return flattenDown(array, [], Infinity)
+  return flattenDown(array, [])
 }
 
 /**


### PR DESCRIPTION
The function `flattenFrom` calls `flattenDown` with 3 parameters, however, the function `flattenDown` only accepts and uses 2. The final parameter (`Infinity`) isn't needed.