### PR TITLE
Added power support for the travis.yml file with ppc64le package: array-flatten

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
-
+arch:
+  - amd64
+  - ppc64le
 notifications:
   email:
     on_success: never


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. 
This helps us simplify testing later when distributions are re-building and re-releasing